### PR TITLE
hides dorms vendors, takes revealing gear out of loadouts

### DIFF
--- a/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
+++ b/_maps/RandomRuins/IceRuins/skyrat/icemoon_underground_syndicate_base1_skyrat.dmm
@@ -831,9 +831,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/vending/dorms{
-	onstation = 0
-	},
 /obj/machinery/airalarm/directional/north{
 	req_access = list(150)
 	},

--- a/_maps/map_files/Blueshift/BlueShift_upper.dmm
+++ b/_maps/map_files/Blueshift/BlueShift_upper.dmm
@@ -6629,9 +6629,6 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/rd)
 "bBK" = (
-/obj/structure/table/abductor,
-/obj/item/clothing/sextoy/magic_wand,
-/obj/item/clothing/mask/leatherwhip,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured_large,
 /area/commons/dorms)
@@ -7977,7 +7974,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/iron/dark/textured_large,
 /area/commons/dorms)
 "bXz" = (
 /obj/structure/closet/crate/freezer{
@@ -12908,13 +12905,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/genetics)
-"dLS" = (
-/obj/structure/chair/x_stand,
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/commons/dorms)
 "dLX" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/firecloset,
@@ -13590,7 +13580,10 @@
 /turf/open/floor/wood/parquet,
 /area/service/theater)
 "dXg" = (
-/turf/open/floor/carpet/purple,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/commons/dorms)
 "dXh" = (
 /obj/machinery/door/firedoor,
@@ -13781,9 +13774,6 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/obj/structure/table/abductor,
-/obj/item/clothing/mask/ballgag,
-/obj/item/clothing/mask/ballgag/choking,
 /turf/open/floor/iron/dark/textured_large,
 /area/commons/dorms)
 "ecd" = (
@@ -23289,10 +23279,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/science/robotics/lab)
-"hPM" = (
-/obj/structure/bed/bdsm_bed,
-/turf/open/floor/iron/dark/textured_large,
-/area/commons/dorms)
 "hQi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -24408,10 +24394,7 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/iron/dark/textured_large,
 /area/commons/dorms)
 "ilh" = (
 /obj/effect/turf_decal/siding/wood,
@@ -28838,7 +28821,6 @@
 /turf/open/indestructible,
 /area/science/test_area)
 "jQl" = (
-/obj/machinery/vending/dorms,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -35097,12 +35079,6 @@
 /obj/structure/closet/secure_closet/security/med,
 /turf/open/floor/iron,
 /area/security/checkpoint/medical)
-"mdu" = (
-/obj/structure/table/abductor,
-/obj/item/lustwish_discount,
-/obj/item/clothing/sextoy/vibroring,
-/turf/open/floor/iron/dark/textured_large,
-/area/commons/dorms)
 "mdw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -35501,17 +35477,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/commons/dorms)
-"mmo" = (
-/obj/structure/table/abductor,
-/obj/item/clothing/sextoy/dildo{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/obj/item/clothing/sextoy/buttplug{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
 /area/commons/dorms)
 "mmr" = (
 /obj/structure/shuttle/engine/heater{
@@ -44342,10 +44307,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain/private)
-"pFG" = (
-/obj/structure/chair/x_stand,
-/turf/open/floor/iron/dark/textured_large,
-/area/commons/dorms)
 "pFL" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8;
@@ -58923,9 +58884,8 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "vdK" = (
-/obj/machinery/vending/dorms,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/iron/dark/textured_large,
 /area/commons/dorms)
 "vdO" = (
 /obj/effect/turf_decal/tile/blue{
@@ -64041,7 +64001,7 @@
 "wVm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/iron/dark/textured_large,
 /area/commons/dorms)
 "wVq" = (
 /obj/item/kirbyplants/random,
@@ -64897,7 +64857,6 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/structure/bed/bdsm_bed,
 /turf/open/floor/iron/dark/textured_large,
 /area/commons/dorms)
 "xkS" = (
@@ -67089,9 +67048,6 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
-/obj/structure/table/abductor,
-/obj/item/clothing/sextoy/double_dildo,
-/obj/item/spanking_pad,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -88462,8 +88418,8 @@ rzb
 ivq
 rML
 hTM
-hPM
-mmo
+aYf
+aYf
 ile
 hTM
 pnN
@@ -88721,7 +88677,7 @@ llU
 hTM
 nkZ
 aYf
-dXg
+aYf
 mTO
 pnN
 xgb
@@ -89235,7 +89191,7 @@ hTM
 hTM
 vdK
 bXv
-vpz
+dXg
 mTO
 xbC
 xgb
@@ -89490,7 +89446,7 @@ jOV
 xsT
 uOh
 hTM
-dLS
+ebo
 bea
 ebo
 hTM
@@ -90004,9 +89960,9 @@ lrm
 xiC
 tra
 hTM
-pFG
+aYf
 bea
-mdu
+aYf
 hTM
 xbC
 xgb

--- a/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2_skyrat.dmm
@@ -4114,7 +4114,6 @@
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/machinery/vending/dorms,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "aED" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation_skyrat.dmm
@@ -43337,7 +43337,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/vending/dorms,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "sBe" = (

--- a/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
+++ b/_maps/map_files/KiloStation/KiloStation_skyrat.dmm
@@ -65404,7 +65404,6 @@
 /obj/structure/sign/poster/official/no_erp{
 	pixel_y = -32
 	},
-/obj/machinery/vending/dorms,
 /turf/open/floor/iron/dark,
 /area/commons/locker)
 "qcN" = (

--- a/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
+++ b/_maps/map_files/MetaStation/MetaStation_skyrat.dmm
@@ -57536,7 +57536,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/vending/dorms,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "svh" = (

--- a/_maps/map_files/NSSJourney/NSSJourney.dmm
+++ b/_maps/map_files/NSSJourney/NSSJourney.dmm
@@ -44448,11 +44448,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"kOB" = (
-/obj/machinery/vending/dorms,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "kOT" = (
 /obj/item/stock_parts/scanning_module{
 	pixel_x = -5;
@@ -53572,7 +53567,6 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "tHv" = (
-/obj/machinery/vending/dorms,
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
 "tHT" = (
@@ -56476,10 +56470,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"wmp" = (
-/obj/machinery/vending/dorms,
-/turf/open/floor/plating,
-/area/security/prison/safe)
 "wnD" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -80253,7 +80243,7 @@ aaw
 aaw
 aaw
 aaJ
-wmp
+oHB
 cOf
 oHB
 oHB
@@ -80627,7 +80617,7 @@ nsM
 fAS
 wCp
 bCq
-kOB
+vLX
 otQ
 vLX
 bCq

--- a/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
+++ b/_maps/map_files/WaterKiloStation/WaterKiloStation.dmm
@@ -77041,7 +77041,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/vending/dorms,
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/poster/official/no_erp{
 	pixel_y = -32

--- a/_maps/map_files/tramstation/tramstation_skyrat.dmm
+++ b/_maps/map_files/tramstation/tramstation_skyrat.dmm
@@ -17026,16 +17026,6 @@
 	},
 /turf/open/floor/carpet,
 /area/commons/vacant_room/office)
-"erC" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/vending/dorms,
-/turf/open/floor/iron/cafeteria,
-/area/commons/locker)
 "erD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -23102,19 +23092,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
-"gtB" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/machinery/vending/dorms{
-	contraband = list(/obj/item/electropack/shockcollar = 4, /obj/item/clothing/neck/kink_collar/locked = 4, /obj/item/clothing/neck/mind_collar = 2, /obj/item/clothing/under/costume/jabroni = 4, /obj/item/clothing/neck/human_petcollar/locked = 4, /obj/item/assembly/signaler = 0, /obj/item/clothing/suit/straight_jacket/kinky_sleepbag = 0, /obj/item/reagent_containers/pill/hexacrocin = 10, /obj/item/reagent_containers/pill/pentacamphor = 5, /obj/item/reagent_containers/glass/bottle/hexacrocin = 4, /obj/item/reagent_containers/glass/bottle/pentacamphor = 2);
-	desc = "A vending machine with various toys. Not for the faint of heart. This one seems to have a reduced inventory.";
-	name = "NanoTrasen Approved LustWish";
-	payment_department = "SEC";
-	products = list(/obj/item/clothing/sextoy/signalvib = 8, /obj/item/assembly/signaler = 0, /obj/item/clothing/sextoy/eggvib = 8, /obj/item/clothing/sextoy/buttplug = 6, /obj/item/clothing/sextoy/nipple_clamps = 4, /obj/item/clothing/sextoy/double_dildo = 3, /obj/item/clothing/sextoy/vibroring = 6, /obj/item/condom_pack = 20, /obj/item/clothing/sextoy/dildo = 8, /obj/item/clothing/sextoy/custom_dildo = 8, /obj/item/tickle_feather = 8, /obj/item/clothing/sextoy/fleshlight = 8, /obj/item/kinky_shocker = 4, /obj/item/clothing/mask/leatherwhip = 4, /obj/item/clothing/sextoy/magic_wand = 4, /obj/item/bdsm_candle = 4, /obj/item/spanking_pad = 4, /obj/item/clothing/sextoy/vibrator = 4, /obj/item/serviette_pack = 10, /obj/item/restraints/handcuffs/lewd = 0, /obj/item/key/collar = 48, /obj/item/pillow = 32, /obj/item/clothing/mask/ballgag = 8, /obj/item/clothing/mask/ballgag/choking = 8, /obj/item/clothing/mask/muzzle/ring = 4, /obj/item/clothing/head/domina_cap = 5, /obj/item/clothing/head/helmet/space/deprivation_helmet = 5, /obj/item/clothing/head/maid = 5, /obj/item/clothing/glasses/blindfold/kinky = 5, /obj/item/clothing/ears/kinky_headphones = 5, /obj/item/clothing/mask/gas/bdsm_mask = 5, /obj/item/reagent_containers/glass/lewd_filter = 5, /obj/item/clothing/glasses/hypno = 4, /obj/item/clothing/head/kitty = 4, /obj/item/clothing/head/rabbitears = 4, /obj/item/clothing/neck/kink_collar = 8, /obj/item/clothing/neck/human_petcollar = 8, /obj/item/clothing/neck/human_petcollar/choker = 8, /obj/item/clothing/neck/human_petcollar/locked/cowcollar = 8, /obj/item/clothing/neck/human_petcollar/locked/bellcollar = 8, /obj/item/clothing/neck/human_petcollar/locked/cross = 8, /obj/item/clothing/neck/human_petcollar/locked/spikecollar = 8, /obj/item/clothing/under/misc/latex_catsuit = 8, /obj/item/clothing/suit/straight_jacket/latex_straight_jacket = 0, /obj/item/clothing/under/costume/maid = 5, /obj/item/clothing/under/rank/civilian/janitor/maid = 5, /obj/item/clothing/under/costume/lewdmaid = 5, /obj/item/clothing/suit/straight_jacket/shackles = 0, /obj/item/clothing/under/stripper_outfit = 5, /obj/item/clothing/under/misc/stripper/bunnysuit = 5, /obj/item/clothing/under/misc/stripper/bunnysuit/white = 5, /obj/item/clothing/under/misc/gear_harness = 4, /obj/item/clothing/gloves/ball_mittens = 8, /obj/item/clothing/gloves/latex_gloves = 8, /obj/item/clothing/gloves/evening = 5, /obj/item/clothing/shoes/latex_socks = 8, /obj/item/clothing/shoes/latexheels = 4, /obj/item/clothing/shoes/dominaheels = 4, /obj/item/clothing/shoes/jackboots/thigh = 3, /obj/item/clothing/shoes/jackboots/knee = 3, /obj/item/clothing/strapon = 6, /obj/item/storage/belt/erpbelt = 5, /obj/item/reagent_containers/pill/crocin = 20, /obj/item/reagent_containers/pill/camphor = 10, /obj/item/reagent_containers/glass/bottle/crocin = 6, /obj/item/reagent_containers/glass/bottle/camphor = 3, /obj/item/reagent_containers/glass/bottle/breast_enlarger = 6, /obj/item/reagent_containers/glass/bottle/penis_enlarger = 6, /obj/item/clothing/glasses/nice_goggles = 1, /obj/item/storage/box/bdsmbed_kit = 0, /obj/item/storage/box/strippole_kit = 0, /obj/item/storage/box/xstand_kit = 0, /obj/item/storage/box/milking_kit = 0)
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "gtJ" = (
 /obj/effect/turf_decal/siding/thinplating/end,
 /obj/machinery/button/door{
@@ -91572,7 +91549,7 @@ aRY
 xgH
 aRW
 arH
-erC
+aUD
 afH
 ogJ
 dSU
@@ -92278,7 +92255,7 @@ htN
 ccM
 ccM
 ccM
-gtB
+uXd
 qKe
 jbD
 fnk

--- a/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
+++ b/modular_skyrat/modules/loadouts/loadout_items/under/loadout_datum_under.dm
@@ -196,14 +196,6 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Green Christmas Suit"
 	item_path = /obj/item/clothing/under/costume/christmas/green
 
-/datum/loadout_item/under/miscellaneous/christmas/female
-	name = "Revealing Christmas Suit"
-	item_path = /obj/item/clothing/under/croptop/christmas
-
-/datum/loadout_item/under/miscellaneous/christmas/female/green
-	name = "Revealing Green Christmas Suit"
-	item_path = /obj/item/clothing/under/croptop/christmas/green
-
 //christmas ends, because every christmas is last christmas
 
 /datum/loadout_item/under/miscellaneous/camo
@@ -543,22 +535,6 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Black Cargo Uniform"
 	item_path = /obj/item/clothing/under/misc/evilcargo
 	restricted_roles = list(JOB_CARGO_TECHNICIAN)
-
-/datum/loadout_item/under/miscellaneous/eve
-	name = "Collection of Leaves"
-	item_path = /obj/item/clothing/under/misc/gear_harness/eve
-
-/datum/loadout_item/under/miscellaneous/adam
-	name = "Leaf"
-	item_path = /obj/item/clothing/under/costume/loincloth/sensor/adam
-
-/datum/loadout_item/under/miscellaneous/loincloth_leather
-	name = "Leather Loincloth"
-	item_path = /obj/item/clothing/under/costume/loincloth/sensor
-
-/datum/loadout_item/under/miscellaneous/loincloth_cloth
-	name = "Cloth Loincloth"
-	item_path = /obj/item/clothing/under/costume/loincloth/cloth/sensor
 
 ////////////////////////////////////////////////////////////////FORMAL UNDERSUITS
 /datum/loadout_item/under/formal


### PR DESCRIPTION

## About The Pull Request

h

## How This Contributes To The Skyrat Roleplay Experience

it doesn't

## Changelog

:cl:
del: removed all /vending/dorms from main maps
del: took away the option to select certain overly revealing clothes in loadouts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
